### PR TITLE
feat: tornar categoria opcional em entradas

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md — Memora
+
+## Estrutura resumida
+
+- `js/supabase-client.js` — toda a camada de dados (Supabase). Funções: `criarEntradaEmNicho`, `criarCategoriaEmNicho`, `buscarEntradas`, etc.
+- `js/editor-nicho.js` — lógica do formulário de criação/edição de entradas
+- `js/app-nicho.js` — lógica da página principal (listagem, filtros, navegação)
+- `editar.html` — formulário de entrada
+- `dashboard.html` — página do nicho (workspace)
+- `SETUP-SUPABASE.sql` / `SETUP-NICHOS-SUPABASE.sql` — schema do banco
+
+## Instruções para a IA
+
+- **Não leia o codebase inteiro.** Use `grep` ou `find` para localizar o símbolo/função relevante e leia apenas esse arquivo.
+- Antes de qualquer tarefa, identifique quais dos arquivos acima são afetados e leia somente eles.
+- Para mudanças de UI: leia `editar.html` ou `dashboard.html` + o JS correspondente.
+- Para mudanças de dados: leia `js/supabase-client.js` e o arquivo de schema SQL relevante.
+- Leitura ampla do codebase só é justificada em refatorações globais ou bugs de integração entre múltiplos módulos.

--- a/editar.html
+++ b/editar.html
@@ -96,10 +96,11 @@
           <!-- Categoria -->
           <div class="form-group">
             <label for="categoria">
-              Categoria <span class="required">*</span>
+              Categoria
             </label>
-            <select id="categoria" class="form-control" required>
+            <select id="categoria" class="form-control">
               <option value="">Selecione uma categoria...</option>
+              <option value="sem-categoria">📁 Sem categoria</option>
               <!-- Opções carregadas via JS -->
             </select>
             <div class="form-hint">Escolha a categoria mais adequada para esta entrada.</div>

--- a/js/editor-nicho.js
+++ b/js/editor-nicho.js
@@ -148,20 +148,18 @@ function renderizarCategorias() {
   const selectCategoria = document.getElementById('categoria');
   if (!selectCategoria) return;
 
-  // Limpar opções existentes (exceto a primeira)
-  selectCategoria.innerHTML = '<option value="">Selecione uma categoria...</option>';
+  selectCategoria.innerHTML =
+    '<option value="">Selecione uma categoria...</option>' +
+    '<option value="sem-categoria">📁 Sem categoria</option>';
 
-  if (estado.categorias.length === 0) {
-    selectCategoria.innerHTML += '<option value="nova">Criar nova categoria</option>';
-  } else {
-    estado.categorias.forEach(categoria => {
-      const option = document.createElement('option');
-      option.value = categoria.id;
-      option.textContent = categoria.nome;
-      selectCategoria.appendChild(option);
-    });
-    selectCategoria.innerHTML += '<option value="nova">Criar nova categoria</option>';
-  }
+  estado.categorias.forEach(categoria => {
+    const option = document.createElement('option');
+    option.value = categoria.id;
+    option.textContent = categoria.nome;
+    selectCategoria.appendChild(option);
+  });
+
+  selectCategoria.innerHTML += '<option value="nova">Criar nova categoria</option>';
 }
 
 /**
@@ -169,7 +167,7 @@ function renderizarCategorias() {
  */
 function preencherFormulario(entrada) {
   document.getElementById('titulo').value = entrada.titulo;
-  document.getElementById('categoria').value = entrada.categoria_id;
+  document.getElementById('categoria').value = entrada.categoria_id ?? 'sem-categoria';
   document.getElementById('conteudo').value = entrada.conteudo;
   
   // Atualizar preview
@@ -225,17 +223,12 @@ async function salvarEntrada() {
     return;
   }
 
-  if (!categoriaId) {
-    mostrarErro('Categoria é obrigatória.');
-    return;
-  }
-
   if (!conteudo) {
     mostrarErro('Conteúdo é obrigatório.');
     return;
   }
 
-  let categoriaFinalId = categoriaId;
+  const categoriaFinalId = categoriaId === 'sem-categoria' || categoriaId === '' ? null : categoriaId;
 
   // Se for criar nova categoria
   if (categoriaId === 'nova') {


### PR DESCRIPTION
Remove a obrigatoriedade de categoria no formulário de entrada:
- `editar.html`: remove `required` do select e adiciona opção fixa "Sem categoria"
- `js/editor-nicho.js`: remove validação que bloqueava save sem categoria, mapeia valor especial para `null`, preserva "Sem categoria" ao renderizar opções e ao preencher o formulário ao editar entradas com `categoria_id = null`
- `CLAUDE.md`: novo arquivo com estrutura do projeto e diretrizes para a IA

https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy