### PR TITLE
feat: entradas sem categoria (categoria opcional)

### DIFF
--- a/js/app-nicho.js
+++ b/js/app-nicho.js
@@ -237,7 +237,9 @@ async function renderizarCategorias() {
   const grid = document.getElementById('categoriasGrid');
   if (!grid) return;
 
-  if (estado.categorias.length === 0) {
+  const entradasSemCat = estado.entradas.filter(e => !e.categoria_id);
+
+  if (estado.categorias.length === 0 && entradasSemCat.length === 0) {
     grid.innerHTML = `
       <div style="grid-column: 1 / -1; text-align: center; padding: 40px;">
         <div style="font-size: 3rem; margin-bottom: 15px;">📂</div>
@@ -249,16 +251,14 @@ async function renderizarCategorias() {
     return;
   }
 
-  grid.innerHTML = estado.categorias.map(cat => {
+  const cardCategoria = (cat) => {
     const entradasCat = estado.entradas.filter(e => e.categoria_id === cat.id);
     const entradasHtml = entradasCat.slice(0, 5).map(e => `
       <li><a href="entrada.html?id=${e.id}&nicho=${estado.nichoId}">${e.titulo}</a></li>
     `).join('');
-    
-    const maisEntradas = entradasCat.length > 5 
-      ? `<li style="color: var(--cor-texto-claro); font-size: 0.85rem; padding: 6px 0;">+ ${entradasCat.length - 5} mais...</li>` 
+    const maisEntradas = entradasCat.length > 5
+      ? `<li style="color: var(--cor-texto-claro); font-size: 0.85rem; padding: 6px 0;">+ ${entradasCat.length - 5} mais...</li>`
       : '';
-
     return `
       <div class="categoria-card">
         <div class="categoria-header">
@@ -276,7 +276,37 @@ async function renderizarCategorias() {
         </ul>
       </div>
     `;
-  }).join('');
+  };
+
+  const cardSemCategoria = () => {
+    const entradasHtml = entradasSemCat.slice(0, 5).map(e => `
+      <li><a href="entrada.html?id=${e.id}&nicho=${estado.nichoId}">${e.titulo}</a></li>
+    `).join('');
+    const maisEntradas = entradasSemCat.length > 5
+      ? `<li style="color: var(--cor-texto-claro); font-size: 0.85rem; padding: 6px 0;">+ ${entradasSemCat.length - 5} mais...</li>`
+      : '';
+    return `
+      <div class="categoria-card">
+        <div class="categoria-header">
+          <div class="categoria-icon" style="background: #6b728020; color: #6b7280;">
+            📁
+          </div>
+          <div>
+            <div class="categoria-titulo">Sem categoria</div>
+            <div class="categoria-contador">${entradasSemCat.length} entrada(s)</div>
+          </div>
+        </div>
+        <ul class="entradas-lista">
+          ${entradasHtml}
+          ${maisEntradas}
+        </ul>
+      </div>
+    `;
+  };
+
+  grid.innerHTML =
+    estado.categorias.map(cat => cardCategoria(cat)).join('') +
+    (entradasSemCat.length > 0 ? cardSemCategoria() : '');
   
   // Remover classe hidden da seção
   const categoriesSection = document.getElementById('categoriesSection');


### PR DESCRIPTION
## Summary

- Categoria deixa de ser obrigatória no formulário de entrada (`editar.html`): removido `required` do `<select>` e adicionada opção fixa "📁 Sem categoria"
- `js/editor-nicho.js`: removida validação que bloqueava save sem categoria; valor especial `sem-categoria` / string vazia é mapeado para `null` antes de persistir; ao editar entradas com `categoria_id = null` o select exibe "Sem categoria" corretamente
- `js/app-nicho.js`: dashboard agora exibe um card sintético "Sem categoria" para entradas com `categoria_id = null` — sem nenhuma alteração no schema do banco
- `CLAUDE.md`: criado com estrutura do projeto e diretrizes de leitura focada para a IA

## Test plan

- [ ] Criar nova entrada **sem selecionar categoria** e salvar — deve persistir com `categoria_id = null`
- [ ] Verificar que o card "Sem categoria" aparece no dashboard do nicho com a entrada recém-criada
- [ ] Editar essa entrada — o campo categoria deve mostrar "📁 Sem categoria" selecionado
- [ ] Editar a entrada e atribuir uma categoria real — deve persistir corretamente e sair do card "Sem categoria"
- [ ] Nicho sem nenhuma entrada: empty state continua aparecendo normalmente
- [ ] Nicho com apenas entradas categorizadas: card "Sem categoria" não aparece
- [ ] Busca por termo ainda exibe "Sem categoria" para entradas sem categoria (comportamento preexistente)

https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy)_