### PR TITLE
feat: nichos/entradas compartilhados — sair, ocultar, autor e criador

### DIFF
--- a/SETUP-OCULTACOES.sql
+++ b/SETUP-OCULTACOES.sql
@@ -1,0 +1,36 @@
+-- =====================================================
+-- MEMORA - Ocultação de entradas por usuário
+-- Execute este SQL no Supabase SQL Editor
+-- =====================================================
+
+-- Tabela de ocultações: cada linha representa uma entrada
+-- que um usuário optou por não ver mais no seu dashboard.
+-- A entrada continua existindo e visível para todos os outros.
+CREATE TABLE IF NOT EXISTS entrada_ocultacoes (
+  user_id    UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  entrada_id TEXT NOT NULL REFERENCES entradas(id)   ON DELETE CASCADE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (user_id, entrada_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ocultacoes_user    ON entrada_ocultacoes(user_id);
+CREATE INDEX IF NOT EXISTS idx_ocultacoes_entrada ON entrada_ocultacoes(entrada_id);
+
+-- RLS
+ALTER TABLE entrada_ocultacoes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Usuário vê suas próprias ocultações"  ON entrada_ocultacoes;
+DROP POLICY IF EXISTS "Usuário insere suas próprias ocultações" ON entrada_ocultacoes;
+DROP POLICY IF EXISTS "Usuário remove suas próprias ocultações" ON entrada_ocultacoes;
+
+CREATE POLICY "Usuário vê suas próprias ocultações"
+  ON entrada_ocultacoes FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE POLICY "Usuário insere suas próprias ocultações"
+  ON entrada_ocultacoes FOR INSERT
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "Usuário remove suas próprias ocultações"
+  ON entrada_ocultacoes FOR DELETE
+  USING (auth.uid() = user_id);

--- a/dashboard.html
+++ b/dashboard.html
@@ -250,6 +250,35 @@
     </div>
   </div>
 
+  <!-- Modal de Confirmação de Saída de Nicho Compartilhado -->
+  <div class="modal-overlay" id="sairModalOverlay">
+    <div class="modal">
+      <div class="modal-header">
+        <h3>Sair do nicho</h3>
+        <button class="modal-close" id="sairModalCloseBtn">
+          <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <line x1="18" y1="6" x2="6" y2="18"></line>
+            <line x1="6" y1="6" x2="18" y2="18"></line>
+          </svg>
+        </button>
+      </div>
+      <div class="modal-body">
+        <div class="delete-warning">
+          <div class="warning-icon">🚪</div>
+          <p>Você perderá o acesso a este nicho e a todas as suas entradas. O conteúdo <strong>não será alterado</strong> para o criador ou demais colaboradores.</p>
+          <p>Deseja continuar?</p>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-secondary" id="sairModalCancelBtn">Cancelar</button>
+        <button type="button" class="btn btn-danger" id="sairModalConfirmBtn">
+          <span id="sairModalText">Sair do nicho</span>
+          <div class="loading-spinner" id="sairModalLoading" style="display: none;"></div>
+        </button>
+      </div>
+    </div>
+  </div>
+
   <!-- Toast Container -->
   <div id="toastContainer" style="position:fixed;bottom:24px;right:24px;z-index:9999;display:flex;flex-direction:column;gap:10px;"></div>
 

--- a/entrada.html
+++ b/entrada.html
@@ -108,6 +108,7 @@
               <div class="entrada-meta">
                 <span class="entrada-categoria" id="entradaCategoria"></span>
                 <span class="entrada-data" id="entradaData"></span>
+                <span class="entrada-autor" id="entradaAutor"></span>
                 <div class="entrada-acoes">
                   <a href="#" id="btnEditar" class="btn btn-secondary btn-sm">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -129,6 +130,9 @@
                       <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 0 2 2z"></path>
                     </svg>
                     Comentários
+                  </button>
+                  <button id="btnOcultar" class="btn btn-secondary btn-sm hidden">
+                    🚫 Ocultar para mim
                   </button>
                   <button id="btnExcluir" class="btn btn-danger btn-sm">
                     <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -236,6 +240,18 @@
       <p>Memora - Sua enciclopédia colaborativa.</p>
     </div>
   </footer>
+
+  <!-- Modal de Confirmação de Ocultação -->
+  <div class="modal-overlay" id="modalOcultar">
+    <div class="modal">
+      <h3 class="modal-titulo">🚫 Ocultar entrada</h3>
+      <p class="modal-texto">Esta entrada desaparecerá do seu dashboard. O conteúdo <strong>não será apagado</strong> para os demais colaboradores.</p>
+      <div class="modal-acoes">
+        <button class="btn btn-secondary" id="btnCancelarOcultar">Cancelar</button>
+        <button class="btn btn-danger" id="btnConfirmarOcultar">Sim, ocultar</button>
+      </div>
+    </div>
+  </div>
 
   <!-- Modal de Confirmação -->
   <div class="modal-overlay" id="modalExcluir">

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -133,7 +133,7 @@ async function renderizarNichos() {
 
   grid.innerHTML = nichosComStats.map(nicho => {
     const badgeCompartilhado = nicho.isShared
-      ? `<span class="badge-compartilhado-card">&#128279; Compartilhado</span>`
+      ? `<span class="badge-compartilhado-card">&#128279; Compartilhado por ${escapeHtml(nicho.criadorNick || 'alguém')}</span>`
       : '';
 
     return `
@@ -174,7 +174,12 @@ async function renderizarNichos() {
           <span>🗑️</span>
           <span>Excluir</span>
         </button>
-        ` : ''}
+        ` : `
+        <button class="nicho-btn nicho-btn-danger" onclick="event.stopPropagation(); abrirModalSair('${nicho.id}')">
+          <span>🚪</span>
+          <span>Sair do nicho</span>
+        </button>
+        `}
       </div>
     </div>
   `;
@@ -512,6 +517,40 @@ async function salvarNicho(nichoId = null) {
   }
 }
 
+function abrirModalSair(nichoId) {
+  const modal = document.getElementById('sairModalOverlay');
+  const confirmBtn = document.getElementById('sairModalConfirmBtn');
+  if (!modal || !confirmBtn) return;
+  confirmBtn.onclick = () => sairDoNichoConfirmado(nichoId);
+  modal.classList.add('active');
+}
+
+async function sairDoNichoConfirmado(nichoId) {
+  const modal = document.getElementById('sairModalOverlay');
+  const confirmBtn = document.getElementById('sairModalConfirmBtn');
+  const btnText = document.getElementById('sairModalText');
+  const spinner = document.getElementById('sairModalLoading');
+
+  confirmBtn.disabled = true;
+  if (btnText) btnText.style.display = 'none';
+  if (spinner) spinner.style.display = 'block';
+
+  try {
+    const ok = await WikiSupabase.sairDoNicho(nichoId);
+    if (!ok) throw new Error('Erro ao sair do nicho.');
+    modal.classList.remove('active');
+    await carregarDashboard();
+    mostrarToast('Você saiu do nicho com sucesso.', 'sucesso');
+  } catch (error) {
+    console.error('Erro ao sair do nicho:', error);
+    mostrarToast(error.message || 'Erro ao sair do nicho. Tente novamente.', 'erro');
+  } finally {
+    confirmBtn.disabled = false;
+    if (btnText) btnText.style.display = 'inline';
+    if (spinner) spinner.style.display = 'none';
+  }
+}
+
 async function excluirNicho(nichoId) {
   const modal = document.getElementById('deleteModalOverlay');
   const deleteModalConfirmBtn = document.getElementById('deleteModalConfirmBtn');
@@ -634,6 +673,15 @@ function configurarEventListeners() {
     document.getElementById('deleteModalOverlay').classList.remove('active');
   });
 
+  // Modal de sair do nicho
+  document.getElementById('sairModalCloseBtn')?.addEventListener('click', () => {
+    document.getElementById('sairModalOverlay').classList.remove('active');
+  });
+
+  document.getElementById('sairModalCancelBtn')?.addEventListener('click', () => {
+    document.getElementById('sairModalOverlay').classList.remove('active');
+  });
+
   // Seletor de ícones
   document.querySelectorAll('.icon-btn').forEach(btn => {
     btn.addEventListener('click', (e) => {
@@ -705,6 +753,13 @@ function configurarEventListeners() {
     if (deleteModal && deleteModal.classList.contains('active')) {
       if (!deleteModal.querySelector('.modal').contains(e.target)) {
         deleteModal.classList.remove('active');
+      }
+    }
+
+    const sairModal = document.getElementById('sairModalOverlay');
+    if (sairModal && sairModal.classList.contains('active')) {
+      if (!sairModal.querySelector('.modal').contains(e.target)) {
+        sairModal.classList.remove('active');
       }
     }
   });

--- a/js/entrada-nicho.js
+++ b/js/entrada-nicho.js
@@ -194,6 +194,13 @@ function renderizarEntrada() {
     data.textContent = `Publicado em ${dataFormatada}`;
   }
 
+  // Exibir autor original
+  const autorEl = document.getElementById('entradaAutor');
+  if (autorEl) {
+    const nick = estado.entrada.criador?.nickname;
+    autorEl.textContent = nick ? `por ${nick}` : '';
+  }
+
   // Atualizar conteúdo
   const body = document.getElementById('entradaBody');
   if (body) {
@@ -250,16 +257,31 @@ function configurarBotoesAcao() {
     });
   }
 
-  // Botão de excluir
+  // Botão de excluir (só para o criador da entrada)
   const btnExcluir = document.getElementById('btnExcluir');
   if (btnExcluir) {
+    if (estado.entrada.user_id !== estado.usuario?.id) {
+      btnExcluir.classList.add('hidden');
+    }
     btnExcluir.addEventListener('click', () => {
       abrirModalExcluir();
     });
   }
 
+  // Botão de ocultar (para entradas de outros usuários)
+  const btnOcultar = document.getElementById('btnOcultar');
+  if (btnOcultar) {
+    if (estado.entrada.user_id !== estado.usuario?.id) {
+      btnOcultar.classList.remove('hidden');
+    }
+    btnOcultar.addEventListener('click', () => {
+      abrirModalOcultar();
+    });
+  }
+
   // Modal de exclusão
   configurarModalExcluir();
+  configurarModalOcultar();
 }
 
 // ============================================
@@ -317,6 +339,38 @@ function configurarModalExcluir() {
   // Confirmar exclusão
   btnConfirmar.addEventListener('click', async () => {
     await excluirEntrada();
+  });
+}
+
+function abrirModalOcultar() {
+  const modal = document.getElementById('modalOcultar');
+  if (modal) modal.style.display = 'flex';
+}
+
+function configurarModalOcultar() {
+  const modal = document.getElementById('modalOcultar');
+  const btnCancelar = document.getElementById('btnCancelarOcultar');
+  const btnConfirmar = document.getElementById('btnConfirmarOcultar');
+
+  if (!modal || !btnCancelar || !btnConfirmar) return;
+
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) modal.style.display = 'none';
+  });
+
+  btnCancelar.addEventListener('click', () => {
+    modal.style.display = 'none';
+  });
+
+  btnConfirmar.addEventListener('click', async () => {
+    btnConfirmar.disabled = true;
+    const ok = await WikiSupabase.ocultarEntradaParaMim(estado.entrada.id);
+    if (ok) {
+      window.location.href = `index.html?nicho=${estado.nichoId}`;
+    } else {
+      btnConfirmar.disabled = false;
+      modal.style.display = 'none';
+    }
   });
 }
 

--- a/js/supabase-client.js
+++ b/js/supabase-client.js
@@ -274,7 +274,7 @@ async function buscarEntradaPorId(id) {
   try {
     const { data, error } = await supabaseClientInstance
       .from('entradas')
-      .select('*')
+      .select('*, criador:users(nickname)')
       .eq('id', id)
       .single();
     
@@ -556,7 +556,7 @@ async function buscarNichos() {
     // Não filtramos por user_id aqui — a política cuida disso.
     const { data, error } = await supabaseClientInstance
       .from('nichos')
-      .select('*')
+      .select('*, criador:users(nickname)')
       .order('nome');
 
     if (error) {
@@ -572,7 +572,8 @@ async function buscarNichos() {
     const nichos = (data || []).map(n => ({
       ...n,
       isOwner: n.user_id === userId,
-      isShared: n.user_id !== userId
+      isShared: n.user_id !== userId,
+      criadorNick: n.criador?.nickname || null
     }));
 
     console.log('Nichos carregados com sucesso:', nichos.length, 'itens');
@@ -859,19 +860,60 @@ async function excluirCategoriaDeNicho(nichoId, categoriaId) {
 async function buscarEntradasPorNicho(nichoId) {
   if (!supabaseClientInstance) supabaseClientInstance = inicializarSupabase();
   if (!supabaseClientInstance) return [];
-  
+
   try {
-    const { data, error } = await supabaseClientInstance
+    const userId = await obterUsuarioIdAtual();
+
+    // Buscar ids ocultados pelo usuário para este nicho
+    let ocultadosIds = [];
+    if (userId) {
+      const { data: ocult } = await supabaseClientInstance
+        .from('entrada_ocultacoes')
+        .select('entrada_id')
+        .eq('user_id', userId);
+      ocultadosIds = (ocult || []).map(o => o.entrada_id);
+    }
+
+    let query = supabaseClientInstance
       .from('entradas')
       .select('*')
       .eq('nicho_id', nichoId)
       .order('titulo');
-    
+
+    if (ocultadosIds.length > 0) {
+      query = query.not('id', 'in', `(${ocultadosIds.join(',')})`);
+    }
+
+    const { data, error } = await query;
     if (error) throw error;
     return data || [];
   } catch (erro) {
     console.error('Erro ao buscar entradas do nicho:', erro);
     return [];
+  }
+}
+
+/**
+ * Oculta uma entrada para o usuário atual.
+ * A entrada continua visível para todos os demais membros do nicho.
+ */
+async function ocultarEntradaParaMim(entradaId) {
+  if (!supabaseClientInstance) supabaseClientInstance = inicializarSupabase();
+  if (!supabaseClientInstance) return false;
+
+  try {
+    const userId = await obterUsuarioIdAtual();
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const { error } = await supabaseClientInstance
+      .from('entrada_ocultacoes')
+      .insert({ user_id: userId, entrada_id: entradaId });
+
+    if (error) throw error;
+    return true;
+  } catch (erro) {
+    console.error('Erro ao ocultar entrada:', erro);
+    return false;
   }
 }
 
@@ -1160,6 +1202,32 @@ async function responderConvite(conviteId, aceitar) {
   } catch (erro) {
     console.error('Erro ao responder convite:', erro);
     throw erro;
+  }
+}
+
+/**
+ * Remove o usuário atual da lista de membros de um nicho compartilhado.
+ * Não afeta o nicho nem seus dados para os demais membros.
+ */
+async function sairDoNicho(nichoId) {
+  if (!supabaseClientInstance) supabaseClientInstance = inicializarSupabase();
+  if (!supabaseClientInstance) return false;
+
+  try {
+    const userId = await obterUsuarioIdAtual();
+    if (!userId) throw new Error('Usuário não autenticado');
+
+    const { error } = await supabaseClientInstance
+      .from('nicho_membros')
+      .delete()
+      .eq('nicho_id', nichoId)
+      .eq('user_id', userId);
+
+    if (error) throw error;
+    return true;
+  } catch (erro) {
+    console.error('Erro ao sair do nicho:', erro);
+    return false;
   }
 }
 
@@ -1566,6 +1634,7 @@ window.WikiSupabase = {
   criarEntradaEmNicho,
   atualizarEntradaEmNicho,
   excluirEntradaDeNicho,
+  excluirEntradaEmNicho: excluirEntradaDeNicho,
   
   // Funções de suporte
   obterEstatisticasNicho,
@@ -1574,6 +1643,8 @@ window.WikiSupabase = {
   // Funções de compartilhamento
   buscarPerfisPorIds,
   verificarSeEhDono,
+  sairDoNicho,
+  ocultarEntradaParaMim,
   // Funções de realtime
   iniciarRealtimeNicho,
   iniciarRealtimeNotificacoes,


### PR DESCRIPTION
$(cat <<'EOF'
## Resumo

Quatro melhorias relacionadas a conteúdo compartilhado, sem breaking changes no schema existente.

### 1. Badge "Compartilhado" mostra o criador do nicho
- `buscarNichos()` faz join `criador:users(nickname)` e propaga `criadorNick`
- Badge em `dashboard.js` passa de "🔗 Compartilhado" para "🔗 Compartilhado por [nickname]"

### 2. Autor original no cabeçalho de cada entrada
- `buscarEntradaPorId()` inclui join `criador:users(nickname)`
- `entrada.html` ganha `<span id="entradaAutor">` renderizado por `entrada-nicho.js` como "por [nickname]"

### 3. Botão "Sair do nicho" em nichos compartilhados
- Cards `isShared` no dashboard ganham botão "🚪 Sair do nicho" (no lugar de Editar/Excluir)
- Nova função `sairDoNicho(nichoId)` em `supabase-client.js`: DELETE em `nicho_membros` para o usuário atual
- Modal de confirmação dedicado em `dashboard.html` (`#sairModalOverlay`)
- Após confirmação: remove o nicho do dashboard sem afetar o criador ou outros membros

### 4. Botão "Ocultar para mim" em entradas de outros autores
- **Nova tabela** `entrada_ocultacoes (user_id, entrada_id)` — ver `SETUP-OCULTACOES.sql`
- `buscarEntradasPorNicho()` filtra entradas ocultas do usuário atual antes de retornar
- `entrada.html` ganha `#btnOcultar` (visível apenas para entradas criadas por outros)
- Modal de confirmação em `entrada.html` (`#modalOcultar`)
- Após confirmação: redireciona ao dashboard; a entrada continua existindo para todos os demais

### Fix colateral
- Alias `excluirEntradaEmNicho → excluirEntradaDeNicho` adicionado ao export de `WikiSupabase` (nome chamado pelo viewer mas ausente no export)

## Migração necessária

Executar `SETUP-OCULTACOES.sql` no Supabase SQL Editor antes de usar a feature de ocultação de entradas.

## Test plan

- [ ] Card de nicho compartilhado exibe "🔗 Compartilhado por [nickname do criador]"
- [ ] Cabeçalho de entrada exibe "por [nickname]" abaixo da data de publicação
- [ ] Botão "Sair do nicho" aparece em nichos compartilhados (não em próprios)
- [ ] Confirmar saída: nicho some do dashboard, dados intactos para o criador
- [ ] Botão "Ocultar para mim" aparece em entradas de outros autores (não nas próprias)
- [ ] Confirmar ocultação: entrada some do dashboard do nicho, visível para os demais
- [ ] Botão "Excluir" continua aparecendo apenas para o criador da entrada

https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy)_