### PR TITLE
fix: três correções pós-merge de compartilhamento

### DIFF
--- a/SETUP-FIX-SAIR-NICHO.sql
+++ b/SETUP-FIX-SAIR-NICHO.sql
@@ -1,0 +1,22 @@
+-- =====================================================
+-- MEMORA - Fix: política DELETE em nicho_membros
+-- Execute este SQL no Supabase SQL Editor
+-- Pré-requisito: SETUP-COMPARTILHAMENTO.sql já executado
+-- =====================================================
+--
+-- O setup original não criou política FOR DELETE em
+-- nicho_membros porque todas as mutações eram feitas via
+-- stored procedures SECURITY DEFINER. A feature "Sair do
+-- nicho" faz um DELETE direto pelo cliente, então precisa
+-- desta política.
+--
+-- Escopo: cada membro só pode remover sua própria linha.
+-- O dono do nicho não está em nicho_membros, portanto
+-- esta política não afeta a posse do nicho.
+-- =====================================================
+
+DROP POLICY IF EXISTS "Membros podem sair do nicho" ON nicho_membros;
+
+CREATE POLICY "Membros podem sair do nicho"
+  ON nicho_membros FOR DELETE
+  USING (user_id = auth.uid());

--- a/js/entrada-nicho.js
+++ b/js/entrada-nicho.js
@@ -310,7 +310,7 @@ function gerarPDF() {
 function abrirModalExcluir() {
   const modal = document.getElementById('modalExcluir');
   if (modal) {
-    modal.style.display = 'flex';
+    modal.classList.add('ativo');
   }
 }
 
@@ -327,13 +327,13 @@ function configurarModalExcluir() {
   // Fechar modal ao clicar fora
   modal.addEventListener('click', (e) => {
     if (e.target === modal) {
-      modal.style.display = 'none';
+      modal.classList.remove('ativo');
     }
   });
 
   // Cancelar exclusão
   btnCancelar.addEventListener('click', () => {
-    modal.style.display = 'none';
+    modal.classList.remove('ativo');
   });
 
   // Confirmar exclusão
@@ -344,7 +344,7 @@ function configurarModalExcluir() {
 
 function abrirModalOcultar() {
   const modal = document.getElementById('modalOcultar');
-  if (modal) modal.style.display = 'flex';
+  if (modal) modal.classList.add('ativo');
 }
 
 function configurarModalOcultar() {
@@ -355,11 +355,11 @@ function configurarModalOcultar() {
   if (!modal || !btnCancelar || !btnConfirmar) return;
 
   modal.addEventListener('click', (e) => {
-    if (e.target === modal) modal.style.display = 'none';
+    if (e.target === modal) modal.classList.remove('ativo');
   });
 
   btnCancelar.addEventListener('click', () => {
-    modal.style.display = 'none';
+    modal.classList.remove('ativo');
   });
 
   btnConfirmar.addEventListener('click', async () => {
@@ -369,7 +369,7 @@ function configurarModalOcultar() {
       window.location.href = `index.html?nicho=${estado.nichoId}`;
     } else {
       btnConfirmar.disabled = false;
-      modal.style.display = 'none';
+      modal.classList.remove('ativo');
     }
   });
 }
@@ -384,7 +384,7 @@ async function excluirEntrada() {
   try {
     // Desabilitar botões
     if (btnExcluir) btnExcluir.disabled = true;
-    if (modal) modal.style.display = 'none';
+    if (modal) modal.classList.remove('ativo');
 
     // Excluir entrada
     const resultado = await WikiSupabase.excluirEntradaEmNicho(estado.nichoId, estado.entrada.id);


### PR DESCRIPTION
## Correções

### 1. Dashboard vazio após merge — join inválido em `buscarNichos` e `buscarEntradaPorId`
O join `criador:users(nickname)` falha no PostgREST porque a FK de `nichos` e `entradas` aponta para `auth.users` (schema separado), não para `public.users`. A query lançava erro silencioso e retornava `[]`, zerando o dashboard. Substituído por chamada a `buscarPerfisPorIds` — o mesmo padrão já usado em outras partes do projeto.

### 2. "Sair do nicho" não persistia — política DELETE ausente em `nicho_membros`
O setup original só criou `FOR SELECT` em `nicho_membros` (mutações eram via stored procedures `SECURITY DEFINER`). O DELETE direto pelo cliente era bloqueado silenciosamente pelo RLS sem retornar erro. Adicionada política `FOR DELETE USING (user_id = auth.uid())`.

**Requer execução de `SETUP-FIX-SAIR-NICHO.sql` no Supabase SQL Editor.**

### 3. Botões "Excluir" e "Ocultar" entrada não abriam o modal
`style.css` controla visibilidade dos `.modal-overlay` via `opacity`/`visibility` com a classe `.ativo` — `display: flex` já é o valor padrão. O código chamava `modal.style.display = 'flex'` que não alterava nada visível. Substituído por `classList.add/remove('ativo')`, o mesmo padrão usado pelo modal de comentários que já funcionava.

## Test plan

- [ ] Dashboard carrega os nichos normalmente (incluindo compartilhados com badge do criador)
- [ ] "Sair do nicho" remove o nicho do dashboard após confirmação (requer SQL do item 2)
- [ ] Botão "Excluir" abre o modal de confirmação em entradas próprias
- [ ] Confirmar exclusão remove a entrada e redireciona ao dashboard do nicho
- [ ] Botão "Ocultar para mim" abre o modal de confirmação em entradas de outros autores
- [ ] Confirmar ocultação redireciona ao dashboard; entrada não aparece mais

https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNoMK6WgpghqYAxFpoYVGy)_